### PR TITLE
Continue without setting TCCL

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/BundleContextImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/BundleContextImpl.java
@@ -853,7 +853,7 @@ public class BundleContextImpl implements BundleContext, EventDispatcher<Object,
 				// move on without setting TCCL (https://github.com/eclipse-equinox/equinox/issues/303)
 				
 				if (debug.DEBUG_GENERAL) {
-					Debug.printStackTrace(t);
+					Debug.printStackTrace(e);
 				}
 
 				return Boolean.FALSE;

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/BundleContextImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/BundleContextImpl.java
@@ -846,8 +846,18 @@ public class BundleContextImpl implements BundleContext, EventDispatcher<Object,
 		ClassLoader previousTCCL = currentThread.getContextClassLoader();
 		ClassLoader contextFinder = container.getContextFinder();
 		if (previousTCCL != contextFinder) {
-			currentThread.setContextClassLoader(container.getContextFinder());
-			return previousTCCL;
+			try {
+				currentThread.setContextClassLoader(container.getContextFinder());
+				return previousTCCL;
+			} catch (SecurityException e) {
+				// move on without setting TCCL (https://github.com/eclipse-equinox/equinox/issues/303)
+				
+				if (debug.DEBUG_GENERAL) {
+					Debug.printStackTrace(t);
+				}
+
+				return Boolean.FALSE;
+			}
 		}
 		return Boolean.FALSE;
 	}


### PR DESCRIPTION
See #303 why setting TCCL can fail in a regular JDK without SecurityManager. 
Therefore catch and continue without setting a TCCL.